### PR TITLE
Julieta testing

### DIFF
--- a/cypress/e2e/footerClick.cy.ts
+++ b/cypress/e2e/footerClick.cy.ts
@@ -1,5 +1,5 @@
 describe("tests the footer component", () => {
-    it("clicks on the frontend and a new window is opened", () => {
+    it("checks that the site that is requested on click has in its contents the name of the repo", () => {
         cy.visit("https://c7c1-study-catalog.netlify.app");
 
         cy.get('[data-testid="frontend-link"]').then(function ($a) {
@@ -9,7 +9,7 @@ describe("tests the footer component", () => {
 
                 .its("body")
 
-                .should("include", "</html>");
+                .should("include", "Julieta-Sanguedolce/C7C1-frontend");
         });
     });
 });

--- a/cypress/e2e/footerClick.cy.ts
+++ b/cypress/e2e/footerClick.cy.ts
@@ -1,0 +1,15 @@
+describe("tests the footer component", () => {
+    it("clicks on the frontend and a new window is opened", () => {
+        cy.visit("https://c7c1-study-catalog.netlify.app");
+
+        cy.get('[data-testid="frontend-link"]').then(function ($a) {
+            const href = $a.prop("href");
+
+            cy.request(href)
+
+                .its("body")
+
+                .should("include", "</html>");
+        });
+    });
+});


### PR DESCRIPTION
The type of test changed because cypress has security constraints when visiting an external website.
now, we check that what we request from the href associated to that link contains in its body the name of the repository.